### PR TITLE
mtr: added wait time flag

### DIFF
--- a/pages/common/mtr.md
+++ b/pages/common/mtr.md
@@ -17,3 +17,7 @@
 - Force IP IPv4 or IPV6:
 
 `mtr -4 {{host}}`
+
+- Define the time to wait before sending another packet to the same hop:
+
+`mtr -i {{seconds}} {{host}}`


### PR DESCRIPTION
Added a command to define the wait time before sending another probe to the same hop.

----
<!-- Thank you for sending a PR! -->
<!-- Please perform the following checks and check all the boxes that apply. -->
<!-- If your PR does not create a command page,
     you can remove the first two checklist items. -->
<!-- If your PR neither creates nor edits a command page (e.g. README edits, etc.)
     you can simply remove the entire checklist. -->

- [X] The page (if new), does not already exist in the repo.

- [X] The page (if new), has been added to the correct platform folder:  
      `common/` if it's common to all platforms, `linux/` if it's Linux-specific, and so on.

- [x] The page has 8 or fewer examples.

- [X] The PR is appropriately titled:  
      `<command name>: add page` for new pages, or `<command name>: <description of changes>` for pages being edited.

- [X] The page follows the [contributing](https://github.com/tldr-pages/tldr/blob/master/CONTRIBUTING.md) guidelines.
